### PR TITLE
Fix Parser for non-list tag pairs

### DIFF
--- a/system/View/Parser.php
+++ b/system/View/Parser.php
@@ -293,6 +293,12 @@ class Parser extends View
             // Loop over each piece of $data, replacing
             // its contents so that we know what to replace in parse()
             $str = '';  // holds the new contents for this tag pair.
+            
+            // If data is not a list of elements, convert single item to a list
+            $is_list = $data === [] || (array_keys($data) === range(0, count($data) - 1));
+            if (!$is_list){
+                $data = [$data];
+            }
 
             foreach ($data as $row) {
                 // Objects that have a `toArray()` method should be


### PR DESCRIPTION
Current Parser code does not work for the example in https://codeigniter4.github.io/userguide/outgoing/view_parser.html#cascading-data To make it work the element should be converted to an array `'location' => [['city' => 'Red City', 'planet' => 'Mars']],`

It only works if parsed data is an array of key/value pairs like in Loop Substitutions example https://codeigniter4.github.io/userguide/outgoing/view_parser.html#loop-substitutions

This fix will convert data to a single-element list of key/value pairs.

How to Reproduce the issue:
```php
<?php

$template = '{name} lives in {location}{city} on {planet}{/location}.';

$data = [
    'name'     => 'George',
    'location' => ['city' => 'Red City', 'planet' => 'Mars'],
];

return $parser->setData($data)->renderString($template);
```

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes <issue number>).
- All bug fixes should be sent to the __"develop"__ branch, this is where the next bug fix version will be developed.
- PRs with any enhancement should be sent to the next minor version branch, e.g. __"4.3"__

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
